### PR TITLE
Add helper scripts for Glaze/Nightshade and watermark decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # CloakNDagger
 An AI cloaking, poisoning and watermarking pipeline to protect your digital content.
+
+## Scripts
+
+Two helper scripts are included in the `scripts/` directory:
+
+* `install_glaze_nightshade.sh` – downloads and installs the [Glaze](https://github.com/SAND-Lab/Glaze) and [Nightshade](https://github.com/SAND-Lab/nightshade) projects. They are required for cloaking and poisoning images.
+* `decipher_watermark.py` – deciphers simple LSB-based watermarks from images.
+
+Run `./scripts/install_glaze_nightshade.sh` to clone and install the dependencies. Run `./scripts/decipher_watermark.py <image>` to decode a watermark from an image file.
+
+## Dependencies
+
+* Python 3 with `numpy` and `Pillow` for the watermark decipher script.
+* `git` and `pip` to install Glaze and Nightshade.

--- a/scripts/decipher_watermark.py
+++ b/scripts/decipher_watermark.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Simple script to decipher LSB-based image watermarks.
+
+This script is an example of how to decode a watermark that has been hidden in
+an image using the least significant bit (LSB) method. It expects a PNG or JPG
+file and outputs the decoded message on stdout.
+"""
+import argparse
+from PIL import Image
+import numpy as np
+
+def decode_lsb(image_path: str) -> str:
+    img = Image.open(image_path)
+    data = np.array(img)
+    # Extract the least significant bit of each pixel channel
+    bits = data & 1
+    flat = bits.flatten()
+    chars = []
+    for i in range(0, len(flat), 8):
+        byte = flat[i:i+8]
+        if len(byte) < 8:
+            break
+        value = 0
+        for bit in byte:
+            value = (value << 1) | int(bit)
+        if value == 0:
+            break
+        chars.append(chr(value))
+    return ''.join(chars)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Decipher LSB watermark")
+    parser.add_argument("image", help="Path to the watermarked image")
+    args = parser.parse_args()
+    message = decode_lsb(args.image)
+    print(message)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_glaze_nightshade.sh
+++ b/scripts/install_glaze_nightshade.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Script to download and install Glaze and Nightshade.
+# These tools are developed by the University of Chicago SAND Lab.
+# They protect artworks by applying perturbations that interfere with AI training.
+#
+# Usage: ./install_glaze_nightshade.sh [install_directory]
+# If no directory is provided, dependencies are installed under 'deps/'.
+set -e
+
+INSTALL_DIR="${1:-deps}"
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+# Clone and install Glaze
+if [ ! -d "glaze" ]; then
+    echo "Cloning Glaze repository..."
+    git clone https://github.com/SAND-Lab/Glaze.git glaze
+fi
+cd glaze
+pip install -e .
+cd ..
+
+# Clone and install Nightshade
+if [ ! -d "nightshade" ]; then
+    echo "Cloning Nightshade repository..."
+    git clone https://github.com/SAND-Lab/nightshade.git nightshade
+fi
+cd nightshade
+pip install -e .
+cd ..
+
+cat <<MSG
+Installation complete.
+Glaze and Nightshade have been installed in: $INSTALL_DIR
+MSG


### PR DESCRIPTION
## Summary
- add a script to clone & install Glaze and Nightshade
- add a Python utility to decipher LSB watermarking
- describe new scripts and their dependencies in README

## Testing
- `python3 scripts/decipher_watermark.py --help` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `bash scripts/install_glaze_nightshade.sh deps_test` *(fails: unable to access 'https://github.com/SAND-Lab/Glaze.git/')*

------
https://chatgpt.com/codex/tasks/task_e_6876cacdd7b4832aa7faf305476c77c7