### PR TITLE
Update installation instructions for Glaze and Nightshade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ An AI cloaking, poisoning and watermarking pipeline to protect your digital cont
 
 Two helper scripts are included in the `scripts/` directory:
 
-* `install_glaze_nightshade.sh` – downloads and installs the [Glaze](https://github.com/SAND-Lab/Glaze) and [Nightshade](https://github.com/SAND-Lab/nightshade) projects. They are required for cloaking and poisoning images.
+* `install_glaze_nightshade.sh` – downloads the Glaze and Nightshade binaries from the University of Chicago SAND Lab mirrors. The script selects the proper archive for Windows or macOS and saves it under `deps/`. After downloading, run the installers manually as described on the [Glaze](https://glaze.cs.uchicago.edu/downloads.html) and [Nightshade](https://nightshade.cs.uchicago.edu/downloads.html) pages. These tools are required for cloaking and poisoning images.
 * `decipher_watermark.py` – deciphers simple LSB-based watermarks from images.
 
-Run `./scripts/install_glaze_nightshade.sh` to clone and install the dependencies. Run `./scripts/decipher_watermark.py <image>` to decode a watermark from an image file.
+Run `./scripts/install_glaze_nightshade.sh` to download the archives. Run `./scripts/decipher_watermark.py <image>` to decode a watermark from an image file.
 
 ## Dependencies
 
 * Python 3 with `numpy` and `Pillow` for the watermark decipher script.
-* `git` and `pip` to install Glaze and Nightshade.
+* `curl` or `wget` to download the Glaze and Nightshade archives.
 
 ## Installation
 

--- a/scripts/install_glaze_nightshade.sh
+++ b/scripts/install_glaze_nightshade.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Script to download and install Glaze and Nightshade.
-# These tools are developed by the University of Chicago SAND Lab.
-# They protect artworks by applying perturbations that interfere with AI training.
+# Script to download Glaze and Nightshade.
+# These tools are developed by the University of Chicago SAND Lab and
+# protect artworks by applying perturbations that interfere with AI training.
 #
 # Usage: ./install_glaze_nightshade.sh [install_directory]
 # If no directory is provided, dependencies are installed under 'deps/'.
@@ -12,25 +12,39 @@ INSTALL_DIR="${1:-deps}"
 mkdir -p "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 
-# Clone and install Glaze
-if [ ! -d "glaze" ]; then
-    echo "Cloning Glaze repository..."
-    git clone https://github.com/SAND-Lab/Glaze.git glaze
-fi
-cd glaze
-pip install -e .
-cd ..
+# Determine URLs based on OS
+OS="$(uname)"
+case "$OS" in
+    Darwin*)
+        GLAZE_URL="https://mirror.cs.uchicago.edu/fawkes/files/glaze/Glaze-2.1-arm64.dmg"
+        NIGHTSHADE_URL="https://mirror.cs.uchicago.edu/fawkes/files/nightshade/Nightshade-1.0.2-m1.dmg"
+        ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+        GLAZE_URL="https://mirror.cs.uchicago.edu/fawkes/files/glaze/Glaze-2.1-Windows.zip"
+        NIGHTSHADE_URL="https://mirror.cs.uchicago.edu/fawkes/files/nightshade/Nightshade-1.0-Windows.zip"
+        ;;
+    *)
+        echo "Unsupported OS. Please download manually:" >&2
+        echo "  Glaze: https://glaze.cs.uchicago.edu/downloads.html" >&2
+        echo "  Nightshade: https://nightshade.cs.uchicago.edu/downloads.html" >&2
+        exit 1
+        ;;
+esac
 
-# Clone and install Nightshade
-if [ ! -d "nightshade" ]; then
-    echo "Cloning Nightshade repository..."
-    git clone https://github.com/SAND-Lab/nightshade.git nightshade
-fi
-cd nightshade
-pip install -e .
-cd ..
+# Download archives
+for URL in "$GLAZE_URL" "$NIGHTSHADE_URL"; do
+    FILE="$(basename "$URL")"
+    if [ ! -f "$FILE" ]; then
+        echo "Downloading $FILE..."
+        curl -L -o "$FILE" "$URL"
+    else
+        echo "$FILE already exists, skipping download"
+    fi
+done
 
 cat <<MSG
-Installation complete.
-Glaze and Nightshade have been installed in: $INSTALL_DIR
+Downloads complete. The archives are located in: $INSTALL_DIR
+Refer to the official pages for installation instructions:
+  Glaze: https://glaze.cs.uchicago.edu/downloads.html
+  Nightshade: https://nightshade.cs.uchicago.edu/downloads.html
 MSG


### PR DESCRIPTION
## Summary
- update install script to download prebuilt Glaze and Nightshade archives
- document new behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687755c239ac832ab9413931a62929ad